### PR TITLE
Fix: curl -s used twice

### DIFF
--- a/extensions-for-aws-managed-shells.sh
+++ b/extensions-for-aws-managed-shells.sh
@@ -144,7 +144,7 @@ curl -sLO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s h
     && sudo mv ./kubectl /usr/local/bin/kubectl
 
 # setup kubecolor 
-LATEST=$(curl -s curl -s https://api.github.com/repositories/302255735/releases/latest) \
+LATEST=$(curl -s https://api.github.com/repositories/302255735/releases/latest) \
 && X86URL=$(echo $LATEST | jq -r '.assets[].browser_download_url' | grep Linux_x86_64.tar.gz) \
 && X86ARTIFACT=$(echo $LATEST  | jq -r '.assets[].name' | grep Linux_x86_64.tar.gz) \
 && curl -L -O $X86URL \


### PR DESCRIPTION

Retrieving kubecolor - 'curl -s' was used again as curl -s arguments. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
